### PR TITLE
Add comment for PlatformIO 5.x

### DIFF
--- a/platformio/platformio.ini
+++ b/platformio/platformio.ini
@@ -28,9 +28,14 @@ upload_speed = 921600
 ;monitor_port = COM11
 
 lib_deps =
+; PlatformIO 4.x
   ESP Async WebServer@~1.2.3
   ESP AsyncTCP@~1.2.2
   AsyncTCP@~1.1.1
+; PlatformIO 5.x, uncomment the below 3 lines and delete the 4 lines above
+;  me-no-dev/ESP Async WebServer @ ~1.2.3
+;  me-no-dev/ESPAsyncTCP @ ~1.2.2
+;  me-no-dev/AsyncTCP @ ~1.1.1
 
 build_flags =
 ; set your debug output (default=Serial)


### PR DESCRIPTION
With 5.x PlatformIO switched fully to owner-based dependency declaration.

-> https://docs.platformio.org/en/v5.0.1/core/migration.html#library-manager