### PR TITLE
It should be possible to start the ConfigPortal without connecting to WiFI

### DIFF
--- a/src/ESPAsync_WiFiManager-Impl.h
+++ b/src/ESPAsync_WiFiManager-Impl.h
@@ -622,7 +622,7 @@ void ESPAsync_WiFiManager::scan()
 
 //////////////////////////////////////////
 
-void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi = true) 
+void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi) 
 {
   _modeless     = true;
   _apName       = apName;

--- a/src/ESPAsync_WiFiManager-Impl.h
+++ b/src/ESPAsync_WiFiManager-Impl.h
@@ -622,7 +622,7 @@ void ESPAsync_WiFiManager::scan()
 
 //////////////////////////////////////////
 
-void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword) 
+void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi = true) 
 {
   _modeless     = true;
   _apName       = apName;
@@ -633,7 +633,7 @@ void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char co
   LOGDEBUG("SET AP STA");
 
   // try to connect
-  if (connectWifi("", "") == WL_CONNECTED)   
+  if (shouldConnectWiFi && connectWifi("", "") == WL_CONNECTED)   
   {
     LOGDEBUG1(F("IP Address:"), WiFi.localIP());
        

--- a/src/ESPAsync_WiFiManager.h
+++ b/src/ESPAsync_WiFiManager.h
@@ -319,7 +319,7 @@ class ESPAsync_WiFiManager
     // If you want to start the config portal
     bool          startConfigPortal();
     bool          startConfigPortal(char const *apName, char const *apPassword = NULL);
-    void startConfigPortalModeless(char const *apName, char const *apPassword);
+    void startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi = true);
 
 
     // get the AP name of the config portal, so it can be used in the callback

--- a/src_cpp/ESPAsync_WiFiManager.cpp
+++ b/src_cpp/ESPAsync_WiFiManager.cpp
@@ -622,7 +622,7 @@ void ESPAsync_WiFiManager::scan()
 
 //////////////////////////////////////////
 
-void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword) 
+void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi) 
 {
   _modeless     = true;
   _apName       = apName;
@@ -633,7 +633,7 @@ void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char co
   LOGDEBUG("SET AP STA");
 
   // try to connect
-  if (connectWifi("", "") == WL_CONNECTED)   
+  if (shouldConnectWiFi && connectWifi("", "") == WL_CONNECTED)   
   {
     LOGDEBUG1(F("IP Address:"), WiFi.localIP());
        

--- a/src_cpp/ESPAsync_WiFiManager.h
+++ b/src_cpp/ESPAsync_WiFiManager.h
@@ -319,7 +319,7 @@ class ESPAsync_WiFiManager
     // If you want to start the config portal
     boolean       startConfigPortal();
     boolean       startConfigPortal(char const *apName, char const *apPassword = NULL);
-    void startConfigPortalModeless(char const *apName, char const *apPassword);
+    void startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi = true);
 
 
     // get the AP name of the config portal, so it can be used in the callback

--- a/src_h/ESPAsync_WiFiManager-Impl.h
+++ b/src_h/ESPAsync_WiFiManager-Impl.h
@@ -622,7 +622,7 @@ void ESPAsync_WiFiManager::scan()
 
 //////////////////////////////////////////
 
-void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi = true) 
+void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi) 
 {
   _modeless     = true;
   _apName       = apName;

--- a/src_h/ESPAsync_WiFiManager-Impl.h
+++ b/src_h/ESPAsync_WiFiManager-Impl.h
@@ -622,7 +622,7 @@ void ESPAsync_WiFiManager::scan()
 
 //////////////////////////////////////////
 
-void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword) 
+void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi = true) 
 {
   _modeless     = true;
   _apName       = apName;
@@ -633,7 +633,7 @@ void ESPAsync_WiFiManager::startConfigPortalModeless(char const *apName, char co
   LOGDEBUG("SET AP STA");
 
   // try to connect
-  if (connectWifi("", "") == WL_CONNECTED)   
+  if (shouldConnectWiFi && connectWifi("", "") == WL_CONNECTED)   
   {
     LOGDEBUG1(F("IP Address:"), WiFi.localIP());
        

--- a/src_h/ESPAsync_WiFiManager.h
+++ b/src_h/ESPAsync_WiFiManager.h
@@ -319,7 +319,7 @@ class ESPAsync_WiFiManager
     // If you want to start the config portal
     bool          startConfigPortal();
     bool          startConfigPortal(char const *apName, char const *apPassword = NULL);
-    void startConfigPortalModeless(char const *apName, char const *apPassword);
+    void startConfigPortalModeless(char const *apName, char const *apPassword, bool shouldConnectWiFi = true);
 
 
     // get the AP name of the config portal, so it can be used in the callback


### PR DESCRIPTION
This PullRequest enables the start of the config portal and setup of the WifiAccessPoint without a blocking call to connectWifi. 

Background:
We use the ESPAsync_WifiManager in a gui application which contains a button to start the config mode. Pressing this button should not freeze the gui.
