### PR TITLE
Allow captive portal to run more than once by closing dnsServer cleanly.

### DIFF
--- a/src/ESPAsync_WiFiManager-Impl.h
+++ b/src/ESPAsync_WiFiManager-Impl.h
@@ -911,7 +911,7 @@ bool  ESPAsync_WiFiManager::startConfigPortal(char const *apName, char const *ap
 
 #if !( ARDUINO_ESP32S2_DEV || ARDUINO_FEATHERS2 || ARDUINO_PROS2 || ARDUINO_MICROS2 ) 
   server->reset();
-  *dnsServer = DNSServer();
+  dnsServer->stop();
 #endif
 
   return  WiFi.status() == WL_CONNECTED;

--- a/src_cpp/ESPAsync_WiFiManager.cpp
+++ b/src_cpp/ESPAsync_WiFiManager.cpp
@@ -908,7 +908,7 @@ bool  ESPAsync_WiFiManager::startConfigPortal(char const *apName, char const *ap
 
 #if !( ARDUINO_ESP32S2_DEV || ARDUINO_FEATHERS2 || ARDUINO_PROS2 || ARDUINO_MICROS2 ) 
   server->reset();
-  *dnsServer = DNSServer();
+  dnsServer->stop();
 #endif
 
   return  WiFi.status() == WL_CONNECTED;

--- a/src_h/ESPAsync_WiFiManager-Impl.h
+++ b/src_h/ESPAsync_WiFiManager-Impl.h
@@ -911,7 +911,7 @@ bool  ESPAsync_WiFiManager::startConfigPortal(char const *apName, char const *ap
 
 #if !( ARDUINO_ESP32S2_DEV || ARDUINO_FEATHERS2 || ARDUINO_PROS2 || ARDUINO_MICROS2 ) 
   server->reset();
-  *dnsServer = DNSServer();
+  dnsServer->stop();
 #endif
 
   return  WiFi.status() == WL_CONNECTED;


### PR DESCRIPTION
Hello,

I noticed that if the Config Portal is started more than once by calling `startConfigPortal(...)` without rebooting the device, then only the first instance functions as a captive portal; at least within 10 seconds of each other. 

This is due to the fact that the `WiFiUdp` object in `DNSServer.h` is never told to `stop()`, and so the OS holds on to port 53. The result of `dnsServer->start(DNS_PORT, "*", WiFi.softAPIP());` in `ESPAsync_WiFiManager::setupConfigPortal()` is never checked; this will return `true` if it can secure the port, `false` otherwise. If you check the result of `dnsServer->start(...)` for the second call to `setupConfigPortal()`, you'll see that it returns `false`. 

The easiest way I found to fix this was to replace `*dnsServer = DNSServer();` in `startConfigPortal(...)` with `dnsServer->stop();`. This will correctly finalise the `WiFiUdp` object and free up the port for next time. 

I'm running this library on a ESP8266 D1 Mini, through PlatformIO. 