### PR TITLE
Fixes Captive Portal hanging depending on active core for AsyncTCP #100

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ IPAddress APStaticSN  = IPAddress(255, 255, 255, 0);
 #define HTTP_PORT           80
 
 AsyncWebServer webServer(HTTP_PORT);
-DNSServer dnsServer;
+AsyncDNSServer dnsServer;
 
 ///////////////////////////////////////////
 // New in v1.4.0
@@ -1222,7 +1222,7 @@ void printLocalTime()
 #define HTTP_PORT           80
 
 AsyncWebServer webServer(HTTP_PORT);
-DNSServer dnsServer;
+AsyncDNSServer dnsServer;
 
 ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer);
 ```

--- a/README.md
+++ b/README.md
@@ -265,10 +265,11 @@ This [**ESPAsync_WiFiManager** library](https://github.com/khoih-prog/ESPAsync_W
  2. [`ESP8266 Core 3.0.2+`](https://github.com/esp8266/Arduino) for ESP8266-based boards. [![Latest release](https://img.shields.io/github/release/esp8266/Arduino.svg)](https://github.com/esp8266/Arduino/releases/latest/)
  3. [`ESP32 Core 2.0.2+`](https://github.com/espressif/arduino-esp32) for ESP32-based boards. [![Latest release](https://img.shields.io/github/release/espressif/arduino-esp32.svg)](https://github.com/espressif/arduino-esp32/releases/latest/)
  4. [`ESPAsyncWebServer v1.2.3+`](https://github.com/me-no-dev/ESPAsyncWebServer) for all ESP32/ESP8266-based boards. You have to use the latest [forked ESPAsyncWebServer](https://github.com/khoih-prog/ESPAsyncWebServer) if the PR [Fix compiler error for ESP32-C3 and mbed TLS v2.7.0+ #970](https://github.com/me-no-dev/ESPAsyncWebServer/pull/970) hasn't been merged.
- 5. [`ESPAsyncTCP v1.2.2+`](https://github.com/me-no-dev/ESPAsyncTCP) for ESP8266-based boards.
- 6. [`AsyncTCP v1.1.1+`](https://github.com/me-no-dev/AsyncTCP) for ESP32-based boards 
- 7. [`ESP_DoubleResetDetector v1.3.1+`](https://github.com/khoih-prog/ESP_DoubleResetDetector) if using DRD feature. To install, check [![arduino-library-badge](https://www.ardu-badge.com/badge/ESP_DoubleResetDetector.svg?)](https://www.ardu-badge.com/ESP_DoubleResetDetector). Use v1.1.0+ if using LittleFS for EP32.
- 8. [`LittleFS_esp32 v1.0.6+`](https://github.com/lorol/LITTLEFS) for ESP32-based boards using LittleFS with ESP32 core v1.0.4-. To install, check [![arduino-library-badge](https://www.ardu-badge.com/badge/LittleFS_esp32.svg?)](https://www.ardu-badge.com/LittleFS_esp32). **Notice**: This [`LittleFS_esp32 library`](https://github.com/lorol/LITTLEFS) has been integrated to Arduino [ESP32 core v1.0.6+](https://github.com/espressif/arduino-esp32/tree/master/libraries/LITTLEFS) and you don't need to install it if using ESP32 core v1.0.6+
+ 5. [`ESPAsyncDNSServer v1.0.0+`](https://github.com/devyte/ESPAsyncDNSServer) for all ESP32/ESP8266-based boards.
+ 6. [`ESPAsyncTCP v1.2.2+`](https://github.com/me-no-dev/ESPAsyncTCP) for ESP8266-based boards.
+ 7. [`AsyncTCP v1.1.1+`](https://github.com/me-no-dev/AsyncTCP) for ESP32-based boards 
+ 8. [`ESP_DoubleResetDetector v1.3.1+`](https://github.com/khoih-prog/ESP_DoubleResetDetector) if using DRD feature. To install, check [![arduino-library-badge](https://www.ardu-badge.com/badge/ESP_DoubleResetDetector.svg?)](https://www.ardu-badge.com/ESP_DoubleResetDetector). Use v1.1.0+ if using LittleFS for EP32.
+ 9. [`LittleFS_esp32 v1.0.6+`](https://github.com/lorol/LITTLEFS) for ESP32-based boards using LittleFS with ESP32 core v1.0.4-. To install, check [![arduino-library-badge](https://www.ardu-badge.com/badge/LittleFS_esp32.svg?)](https://www.ardu-badge.com/LittleFS_esp32). **Notice**: This [`LittleFS_esp32 library`](https://github.com/lorol/LITTLEFS) has been integrated to Arduino [ESP32 core v1.0.6+](https://github.com/espressif/arduino-esp32/tree/master/libraries/LITTLEFS) and you don't need to install it if using ESP32 core v1.0.6+
  
 ---
 ---

--- a/examples/Async_AutoConnect/Async_AutoConnect.ino
+++ b/examples/Async_AutoConnect/Async_AutoConnect.ino
@@ -98,7 +98,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -669,7 +669,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 ) 
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AutoConnectAP");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AutoConnectAP");
 #endif

--- a/examples/Async_AutoConnectWithFSParameters/Async_AutoConnectWithFSParameters.ino
+++ b/examples/Async_AutoConnectWithFSParameters/Async_AutoConnectWithFSParameters.ino
@@ -101,7 +101,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -890,7 +890,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 ) 
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AutoConnect-FSParams");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AutoConnect-FSParams");
 #endif

--- a/examples/Async_AutoConnectWithFSParametersAndCustomIP/Async_AutoConnectWithFSParametersAndCustomIP.ino
+++ b/examples/Async_AutoConnectWithFSParametersAndCustomIP/Async_AutoConnectWithFSParametersAndCustomIP.ino
@@ -102,7 +102,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -810,7 +810,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AutoConnect-FSParams");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AutoConnect-FSParams");
 #endif

--- a/examples/Async_AutoConnectWithFeedback/Async_AutoConnectWithFeedback.ino
+++ b/examples/Async_AutoConnectWithFeedback/Async_AutoConnectWithFeedback.ino
@@ -98,7 +98,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -276,7 +276,7 @@ IPAddress APStaticSN  = IPAddress(255, 255, 255, 0);
 #define HTTP_PORT           80
 
 AsyncWebServer webServer(HTTP_PORT);
-DNSServer dnsServer;
+AsyncDNSServer dnsServer;
 
 ///////////////////////////////////////////
 // New in v1.4.0
@@ -682,7 +682,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AutoConnectWithFeedBack");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AutoConnectWithFeedBack");
 #endif

--- a/examples/Async_AutoConnectWithFeedbackLED/Async_AutoConnectWithFeedbackLED.ino
+++ b/examples/Async_AutoConnectWithFeedbackLED/Async_AutoConnectWithFeedbackLED.ino
@@ -99,7 +99,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -712,7 +712,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AutoConnectFeedBackLED");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AAutoConnectFeedBackLED");
 #endif

--- a/examples/Async_ConfigOnDRD_FS_MQTT_Ptr/Async_ConfigOnDRD_FS_MQTT_Ptr.ino
+++ b/examples/Async_ConfigOnDRD_FS_MQTT_Ptr/Async_ConfigOnDRD_FS_MQTT_Ptr.ino
@@ -117,7 +117,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -855,7 +855,7 @@ void wifi_manager()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 ) 
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "ConfigOnDRD-FS-MQTT");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "ConfigOnDRD-FS-MQTT");
 #endif

--- a/examples/Async_ConfigOnDRD_FS_MQTT_Ptr_Complex/Async_ConfigOnDRD_FS_MQTT_Ptr_Complex.ino
+++ b/examples/Async_ConfigOnDRD_FS_MQTT_Ptr_Complex/Async_ConfigOnDRD_FS_MQTT_Ptr_Complex.ino
@@ -120,7 +120,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -907,7 +907,7 @@ void wifi_manager()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "ConfigOnSwichFS-MQTT");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "ConfigOnSwichFS-MQTT");
 #endif

--- a/examples/Async_ConfigOnDRD_FS_MQTT_Ptr_Medium/Async_ConfigOnDRD_FS_MQTT_Ptr_Medium.ino
+++ b/examples/Async_ConfigOnDRD_FS_MQTT_Ptr_Medium/Async_ConfigOnDRD_FS_MQTT_Ptr_Medium.ino
@@ -117,7 +117,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -893,7 +893,7 @@ void wifi_manager()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )  
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "ConfigOnSwichFS-MQTT");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "ConfigOnSwichFS-MQTT");
 #endif

--- a/examples/Async_ConfigOnDoubleReset/Async_ConfigOnDoubleReset.ino
+++ b/examples/Async_ConfigOnDoubleReset/Async_ConfigOnDoubleReset.ino
@@ -124,7 +124,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -772,7 +772,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AsyncConfigOnDoubleReset");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
 
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AsyncConfigOnDoubleReset");
 #endif

--- a/examples/Async_ConfigOnDoubleReset_Multi/Async_ConfigOnDoubleReset_Multi.ino
+++ b/examples/Async_ConfigOnDoubleReset_Multi/Async_ConfigOnDoubleReset_Multi.ino
@@ -128,7 +128,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AsyncConfigOnDoubleReset");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
 
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AsyncConfigOnDoubleReset");
 #endif

--- a/examples/Async_ConfigOnDoubleReset_TZ/Async_ConfigOnDoubleReset_TZ.ino
+++ b/examples/Async_ConfigOnDoubleReset_TZ/Async_ConfigOnDoubleReset_TZ.ino
@@ -124,7 +124,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -772,7 +772,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AsyncConfigOnDoubleReset");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
 
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AsyncConfigOnDoubleReset");
 #endif

--- a/examples/Async_ConfigOnStartup/Async_ConfigOnStartup.ino
+++ b/examples/Async_ConfigOnStartup/Async_ConfigOnStartup.ino
@@ -114,7 +114,7 @@
 #else
 #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.0
   #include <ESP8266WiFiMulti.h>
@@ -713,7 +713,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AsyncConfigOnStartup");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AsyncConfigOnStartup");
 #endif

--- a/examples/Async_ConfigOnSwitch/Async_ConfigOnSwitch.ino
+++ b/examples/Async_ConfigOnSwitch/Async_ConfigOnSwitch.ino
@@ -111,7 +111,7 @@
 #else
 #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.0
   #include <ESP8266WiFiMulti.h>
@@ -835,7 +835,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AsyncConfigOnSwitch");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AsyncConfigOnSwitch");
 #endif
@@ -1082,7 +1082,7 @@ void loop()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "ConfigOnSwitch");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "ConfigOnSwitch");
 #endif

--- a/examples/Async_ConfigOnSwitchFS/Async_ConfigOnSwitchFS.ino
+++ b/examples/Async_ConfigOnSwitchFS/Async_ConfigOnSwitchFS.ino
@@ -138,7 +138,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -1001,7 +1001,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "ConfigOnSwitchFS");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "ConfigOnSwitchFS");
 #endif
@@ -1246,7 +1246,7 @@ void loop()
     //ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer);
     // Use this to personalize DHCP hostname (RFC952 conformed)
     AsyncWebServer webServer(HTTP_PORT);
-    DNSServer dnsServer;
+    AsyncDNSServer dnsServer;
     
     ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "ConfigOnSwitchFS");
 

--- a/examples/Async_ConfigOnSwitchFS_MQTT_Ptr/Async_ConfigOnSwitchFS_MQTT_Ptr.ino
+++ b/examples/Async_ConfigOnSwitchFS_MQTT_Ptr/Async_ConfigOnSwitchFS_MQTT_Ptr.ino
@@ -124,7 +124,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -932,7 +932,7 @@ void wifi_manager()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "ConfigOnSwichFS-MQTT");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "ConfigOnSwichFS-MQTT");
 #endif

--- a/examples/Async_ConfigPortalParamsOnSwitch/Async_ConfigPortalParamsOnSwitch.ino
+++ b/examples/Async_ConfigPortalParamsOnSwitch/Async_ConfigPortalParamsOnSwitch.ino
@@ -116,7 +116,7 @@
 
   #include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
   //needed for library
-  #include <DNSServer.h>
+  #include <ESPAsyncDNSServer.h>
 
   // From v1.1.1
   #include <ESP8266WiFiMulti.h>
@@ -962,7 +962,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, NULL, "AsyncCP-ParamsOnSW");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AsyncCP-ParamsOnSW");
 #endif  
@@ -1210,7 +1210,7 @@ void loop()
     //ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer);
     // Use this to personalize DHCP hostname (RFC952 conformed)
     AsyncWebServer webServer(HTTP_PORT);
-    DNSServer dnsServer;
+    AsyncDNSServer dnsServer;
   
     ESPAsync_WiFiManager ESPAsync_wifiManager(&webServer, &dnsServer, "AsyncCP-ParamsOnSW");
 

--- a/examples/Async_ESP32_FSWebServer/Async_ESP32_FSWebServer.ino
+++ b/examples/Async_ESP32_FSWebServer/Async_ESP32_FSWebServer.ino
@@ -261,7 +261,7 @@ String host = "async-esp32fs";
 #define HTTP_PORT     80
 
 AsyncWebServer server(HTTP_PORT);
-//DNSServer dnsServer;
+//AsyncDNSServer dnsServer;
 
 AsyncEventSource events("/events");
 
@@ -710,7 +710,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&server, NULL, "AsyncESP32-FSWebServer");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&server, &dnsServer, "AsyncESP32-FSWebServer");
 #endif

--- a/examples/Async_ESP32_FSWebServer_DRD/Async_ESP32_FSWebServer_DRD.ino
+++ b/examples/Async_ESP32_FSWebServer_DRD/Async_ESP32_FSWebServer_DRD.ino
@@ -294,7 +294,7 @@ String host = "async-esp32fs";
 #define HTTP_PORT     80
 
 AsyncWebServer server(HTTP_PORT);
-DNSServer dnsServer;
+AsyncDNSServer dnsServer;
 
 AsyncEventSource events("/events");
 
@@ -752,7 +752,7 @@ void setup()
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )
   ESPAsync_WiFiManager ESPAsync_wifiManager(&server, NULL, "AsyncESP32-FSWebServer");
 #else
-  DNSServer dnsServer;
+  AsyncDNSServer dnsServer;
   
   ESPAsync_WiFiManager ESPAsync_wifiManager(&server, &dnsServer, "AsyncESP32-FSWebServer");
 #endif

--- a/examples/Async_ESP_FSWebServer/Async_ESP_FSWebServer.ino
+++ b/examples/Async_ESP_FSWebServer/Async_ESP_FSWebServer.ino
@@ -42,7 +42,7 @@
 
 #include <ESP8266WiFi.h>
 #include <WiFiClient.h>
-#include <DNSServer.h>
+#include <ESPAsyncDNSServer.h>
 #include <ESP8266mDNS.h>
 
 // From v1.1.0
@@ -226,7 +226,7 @@ String host = "async-esp8266fs";
 #define HTTP_PORT     80
 
 AsyncWebServer server(HTTP_PORT);
-DNSServer dnsServer;
+AsyncDNSServer dnsServer;
 
 AsyncEventSource events("/events");
 

--- a/examples/Async_ESP_FSWebServer_DRD/Async_ESP_FSWebServer_DRD.ino
+++ b/examples/Async_ESP_FSWebServer_DRD/Async_ESP_FSWebServer_DRD.ino
@@ -42,7 +42,7 @@
 
 #include <ESP8266WiFi.h>
 #include <WiFiClient.h>
-#include <DNSServer.h>
+#include <ESPAsyncDNSServer.h>
 #include <ESP8266mDNS.h>
 
 // From v1.1.0
@@ -241,7 +241,7 @@ String host = "async-esp8266fs";
 #define HTTP_PORT     80
 
 AsyncWebServer server(HTTP_PORT);
-DNSServer dnsServer;
+AsyncDNSServer dnsServer;
 
 AsyncEventSource events("/events");
 

--- a/src/ESPAsync_WiFiManager-Impl.h
+++ b/src/ESPAsync_WiFiManager-Impl.h
@@ -346,7 +346,7 @@ void ESPAsync_WiFiManager::setupConfigPortal()
   {
     dnsServer->setErrorReplyCode(AsyncDNSReplyCode::NoError);
     
-    // DNSServer started with "*" domain name, all DNS requests will be passsed to WiFi.softAPIP()
+    // AsyncDNSServer started with "*" domain name, all DNS requests will be passsed to WiFi.softAPIP()
     if (! dnsServer->start(DNS_PORT, "*", WiFi.softAPIP()))
     {
       // No socket available

--- a/src/ESPAsync_WiFiManager-Impl.h
+++ b/src/ESPAsync_WiFiManager-Impl.h
@@ -182,7 +182,7 @@ char* ESPAsync_WiFiManager::getRFC952_hostname(const char* iHostname)
 
 //////////////////////////////////////////
 
-ESPAsync_WiFiManager::ESPAsync_WiFiManager(AsyncWebServer * webserver, DNSServer *dnsserver, const char *iHostname)
+ESPAsync_WiFiManager::ESPAsync_WiFiManager(AsyncWebServer * webserver, AsyncDNSServer *dnsserver, const char *iHostname)
 {
 
   server    = webserver;
@@ -328,7 +328,7 @@ void ESPAsync_WiFiManager::setupConfigPortal()
   #endif
 
   if (!dnsServer)
-    dnsServer = new DNSServer;
+    dnsServer = new AsyncDNSServer;
 #endif    // ( USING_ESP32_S2 || USING_ESP32_C3 )
 
   // optional soft ip config
@@ -344,7 +344,7 @@ void ESPAsync_WiFiManager::setupConfigPortal()
   /* Setup the DNS server redirecting all the domains to the apIP */
   if (dnsServer)
   {
-    dnsServer->setErrorReplyCode(DNSReplyCode::NoError);
+    dnsServer->setErrorReplyCode(AsyncDNSReplyCode::NoError);
     
     // DNSServer started with "*" domain name, all DNS requests will be passsed to WiFi.softAPIP()
     if (! dnsServer->start(DNS_PORT, "*", WiFi.softAPIP()))
@@ -756,9 +756,6 @@ void ESPAsync_WiFiManager::criticalLoop()
 
 void ESPAsync_WiFiManager::safeLoop()
 {
-  #ifndef USE_EADNS	
-  dnsServer->processNextRequest();
-  #endif
 }
 
 ///////////////////////////////////////////////////////////
@@ -807,10 +804,7 @@ bool  ESPAsync_WiFiManager::startConfigPortal(char const *apName, char const *ap
 #if ( USING_ESP32_S2 || USING_ESP32_C3 )   
     // Fix ESP32-S2 issue with WebServer (https://github.com/espressif/arduino-esp32/issues/4348)
     delay(1);
-#else
-    //DNS
-    if (dnsServer)
-      dnsServer->processNextRequest();    
+#else 
     
     //
     //  we should do a scan every so often here and

--- a/src/ESPAsync_WiFiManager.hpp
+++ b/src/ESPAsync_WiFiManager.hpp
@@ -204,7 +204,7 @@
   #include <ESPAsyncWebServer.h>
 #endif
 
-#include <DNSServer.h>
+#include <ESPAsyncDNSServer.h>
 #include <memory>
 #undef min
 #undef max
@@ -470,7 +470,7 @@ class ESPAsync_WiFiManager
 {
   public:
 
-    ESPAsync_WiFiManager(AsyncWebServer * webserver, DNSServer *dnsserver, const char *iHostname = "");
+    ESPAsync_WiFiManager(AsyncWebServer * webserver, AsyncDNSServer *dnsserver, const char *iHostname = "");
 
     ~ESPAsync_WiFiManager();
     
@@ -736,7 +736,7 @@ class ESPAsync_WiFiManager
 
   private:
   
-    DNSServer      *dnsServer;
+    AsyncDNSServer      *dnsServer;
 
     AsyncWebServer *server;
 


### PR DESCRIPTION
Fixes Captive Portal hanging depending on active core for AsyncTCP #100 by switching from DNSServer to AsyncDNSServer.