### PR TITLE
fix: using random CH for non-password use too

### DIFF
--- a/src/ESPAsync_WiFiManager-Impl.h
+++ b/src/ESPAsync_WiFiManager-Impl.h
@@ -412,18 +412,9 @@ void ESPAsync_WiFiManager::setupConfigPortal()
   else
     channel = _WiFiAPChannel;
 
-  if (_apPassword != NULL)
-  {
-    LOGWARN1(F("AP Channel ="), channel);
+  LOGWARN1(F("AP Channel ="), channel);
 
-    //WiFi.softAP(_apName, _apPassword);//password option
-    WiFi.softAP(_apName, _apPassword, channel);
-  }
-  else
-  {
-    // Can't use channel here
-    WiFi.softAP(_apName);
-  }
+  WiFi.softAP(_apName, _apPassword, channel);
 
   delay(500); // Without delay I've seen the IP address blank
 

--- a/src/ESPAsync_WiFiManager-Impl.h
+++ b/src/ESPAsync_WiFiManager-Impl.h
@@ -863,6 +863,9 @@ bool ESPAsync_WiFiManager::startConfigPortal(char const *apName, char const *apP
     }
 #endif    // ( USING_ESP32_S2 || USING_ESP32_C3 )
 
+    // yield before processing our flags "connect" and/or "stopConfigPortal"
+    yield();
+
     if (connect)
     {
       TimedOut = false;
@@ -905,13 +908,13 @@ bool ESPAsync_WiFiManager::startConfigPortal(char const *apName, char const *apP
 
     if (stopConfigPortal)
     {
+      TimedOut = false;
+
       LOGERROR("Stop ConfigPortal");
 
       stopConfigPortal = false;
       break;
     }
-
-    yield();
 
 #if ( defined(TIME_BETWEEN_CONFIG_PORTAL_LOOP) && (TIME_BETWEEN_CONFIG_PORTAL_LOOP > 0) )
   #if (_ESPASYNC_WIFIMGR_LOGLEVEL_ > 3)   
@@ -1823,9 +1826,6 @@ void ESPAsync_WiFiManager::handleWifiSave(AsyncWebServerRequest *request)
   LOGDEBUG(F("Sent wifi save page"));
 
   connect = true; //signal ready to connect/reset
-
-  // Restore when Press Save WiFi
-  _configPortalTimeout = DEFAULT_PORTAL_TIMEOUT;
 }
 
 //////////////////////////////////////////
@@ -1879,9 +1879,6 @@ void ESPAsync_WiFiManager::handleServerClose(AsyncWebServerRequest *request)
   stopConfigPortal = true; //signal ready to shutdown config portal
 
   LOGDEBUG(F("Sent server close page"));
-
-  // Restore when Press Save WiFi
-  _configPortalTimeout = DEFAULT_PORTAL_TIMEOUT;
 }
 
 //////////////////////////////////////////

--- a/src/ESPAsync_WiFiManager.hpp
+++ b/src/ESPAsync_WiFiManager.hpp
@@ -309,12 +309,12 @@ typedef struct
 ////////////////////////////////////////////////////
 
 #ifndef TIME_BETWEEN_MODAL_SCANS
-  // Default to 30s
+  // Default to 120s
   #define TIME_BETWEEN_MODAL_SCANS          120000UL
 #endif
 
 #ifndef TIME_BETWEEN_MODELESS_SCANS
-  // Default to 60s
+  // Default to 120s
   #define TIME_BETWEEN_MODELESS_SCANS       120000UL
 #endif
 


### PR DESCRIPTION
due to the fact that the `yield` was AFTER the processing of connect and stop flag.. the loop would keep on for one last check.

BUT, if we modify the timeout in our handlers, the loop may stop WITHOUT handling our flags..