### PR TITLE
fix: ending portal loop without processing its flags

### DIFF
--- a/src/ESPAsync_WiFiManager-Impl.h
+++ b/src/ESPAsync_WiFiManager-Impl.h
@@ -872,6 +872,9 @@ bool ESPAsync_WiFiManager::startConfigPortal(char const *apName, char const *apP
     }
 #endif    // ( USING_ESP32_S2 || USING_ESP32_C3 )
 
+    // yield before processing our flags "connect" and/or "stopConfigPortal"
+    yield();
+
     if (connect)
     {
       TimedOut = false;
@@ -919,8 +922,6 @@ bool ESPAsync_WiFiManager::startConfigPortal(char const *apName, char const *apP
       stopConfigPortal = false;
       break;
     }
-
-    yield();
 
 #if ( defined(TIME_BETWEEN_CONFIG_PORTAL_LOOP) && (TIME_BETWEEN_CONFIG_PORTAL_LOOP > 0) )
   #if (_ESPASYNC_WIFIMGR_LOGLEVEL_ > 3)   
@@ -1832,9 +1833,6 @@ void ESPAsync_WiFiManager::handleWifiSave(AsyncWebServerRequest *request)
   LOGDEBUG(F("Sent wifi save page"));
 
   connect = true; //signal ready to connect/reset
-
-  // Restore when Press Save WiFi
-  _configPortalTimeout = DEFAULT_PORTAL_TIMEOUT;
 }
 
 //////////////////////////////////////////
@@ -1888,9 +1886,6 @@ void ESPAsync_WiFiManager::handleServerClose(AsyncWebServerRequest *request)
   stopConfigPortal = true; //signal ready to shutdown config portal
 
   LOGDEBUG(F("Sent server close page"));
-
-  // Restore when Press Save WiFi
-  _configPortalTimeout = DEFAULT_PORTAL_TIMEOUT;
 }
 
 //////////////////////////////////////////

--- a/src/ESPAsync_WiFiManager-Impl.h
+++ b/src/ESPAsync_WiFiManager-Impl.h
@@ -917,6 +917,8 @@ bool ESPAsync_WiFiManager::startConfigPortal(char const *apName, char const *apP
 
     if (stopConfigPortal)
     {
+      TimedOut = false;
+
       LOGERROR("Stop ConfigPortal");
 
       stopConfigPortal = false;


### PR DESCRIPTION
since the yield was AFTER processing the flags (connect/stop)..
AND we were modifying the loop-criteria, the loop could end BEFORE we had processed our flags!

SO, yield before and there is no need to modify the timeout at all :)